### PR TITLE
Fix Atom style deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spacegray-dark-neue-ui",
   "theme": "ui",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A better port of the Spacegray Sublime theme by Gadzhi Kharkharov.",
   "license": "MIT",
   "repository": "https://github.com/nathanbuchar/atom-spacegray-dark-ui",
@@ -14,6 +14,6 @@
     "clean"
   ],
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.13.0 <2.0.0"
   }
 }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -23,18 +23,18 @@ atom-text-editor[mini].is-focused {
   to { background-color: null; }
 }
 
-atom-text-editor .cursors, atom-text-editor::shadow .cursors {
+atom-text-editor .cursors, atom-text-editor.editor .cursors {
   position: relative;
   z-index: 9001;
 }
 
-atom-text-editor::shadow .highlighted.selection .region {
+atom-text-editor.editor .highlighted.selection .region {
   -webkit-animation-name: highlight;
   -webkit-animation-duration: 1s;
   -webkit-animation-iteration-count: 1;
 }
 
-atom-text-editor .gutter, atom-text-editor::shadow .gutter {
+atom-text-editor .gutter, atom-text-editor.editor .gutter {
   color: lighten(@panel-heading-background-color, 25%);
 
   .line-number {


### PR DESCRIPTION
As of Atom 1.13.0, [selectors using the Shadow DOM have been deprecated](http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html). Themes that use them show an annoying little deprecation warning in Atom's status bar:

![Deprecation warning in Atom](https://cloud.githubusercontent.com/assets/303731/22000816/3a0c2c5a-dbf6-11e6-9561-13c2020db347.png)

This PR removes references to Shadow DOM selectors. The full list of changes were given by the Deprecation Cop plugin.